### PR TITLE
Fix totem not disappearing immediately when red flash disabled

### DIFF
--- a/XiTimers.lua
+++ b/XiTimers.lua
@@ -471,7 +471,16 @@ function XiTimers:Stop(timer)
     if timer == 1 then
         self.button.time:Hide()
         self.button.cooldown:Hide()
-    end 
+    end
+    -- Stop any running flash animations to ensure immediate visual update
+    if timer <= self.numButtonTimers then
+        self.button.Flash.animation:Stop()
+        self.button.Flash:Hide()
+        if self.button.icons[timer] and self.button.icons[timer].animation then
+            self.button.icons[timer].animation:Stop()
+        end
+        self.flashIsAnimating = false
+    end
     if not self.dontAlpha then self:SetIconAlpha(self.button.icons[timer], self.alpha or 0.4) end
     if self.reverseAlpha then self:SetIconAlpha(self.button.icons[timer],self.maxAlpha) end
     if self.procFlash then self.button.bar:Hide() end


### PR DESCRIPTION
When FlashRed setting is disabled, totems would remain visible at partial opacity for several seconds after expiring instead of disappearing immediately. This was because the icon flash animation would continue running after the timer expired.

The fix stops any running flash animations in the Stop() function and ensures the Flash texture is hidden immediately when a timer expires.

Fixes #3